### PR TITLE
Add NavigationState and sheet presentation

### DIFF
--- a/Modules/Home/Sources/Home/Router/HomeRouter.swift
+++ b/Modules/Home/Sources/Home/Router/HomeRouter.swift
@@ -4,35 +4,40 @@ import Factory
 import HomeInterface
 import Core
 
+class HomeNavigationState: ObservableObject {
+    @Published var routes: [HomeRoute] = []
+}
+
 final public class HomeRouterImplementation: HomeRouter {
-    
-    public init() { }
+
+    var navigationState: HomeNavigationState
+
+    public init() {
+        navigationState = HomeNavigationState()
+    }
     
     // MARK: - Navigation
-    
-    @Published public var routes = [HomeRoute]()
-    public var routesPublisher: Published<[HomeRoute]>.Publisher { $routes }
-    
+
     public func push(to screen: HomeRoute) {
-        routes.append(screen)
+        navigationState.routes.append(screen)
     }
     
     public func push(multiple screens: [HomeRoute]) {
-        routes.append(contentsOf: screens)
+        navigationState.routes.append(contentsOf: screens)
     }
 
     public func pop() {
-        _ = routes.popLast()
+        _ = navigationState.routes.popLast()
     }
     
     public func popToRoot() {
-        routes = []
+        navigationState.routes = []
     }
     
     // MARK: - Navigation
     
     public func entryView() -> AnyView {
-        HomeView().toAnyView()
+        HomeView(navigationState: navigationState).toAnyView()
     }
     
     public func presentAccountList() {

--- a/Modules/Home/Sources/Home/Stories/Home/HomeView.swift
+++ b/Modules/Home/Sources/Home/Stories/Home/HomeView.swift
@@ -6,9 +6,11 @@ import HomeInterface
 struct HomeView: View {
     
     @ObservedObject private var viewModel: HomeViewModel = Container.shared.homeViewModel()
-    
+
+    @ObservedObject var navigationState: HomeNavigationState
+
     var body: some View {
-        NavigationStack(path: $viewModel.routes) {
+        NavigationStack(path: $navigationState.routes) {
             VStack(spacing: 24) {
                 AsyncButton(action: {
                     await viewModel.performAction(.pressedAccountList)

--- a/Modules/Home/Sources/Home/Stories/Home/HomeViewModel.swift
+++ b/Modules/Home/Sources/Home/Stories/Home/HomeViewModel.swift
@@ -2,28 +2,19 @@ import Foundation
 import Factory
 import Core
 import HomeInterface
+import MainInterface
+import SettingsInterface
 
 class HomeViewModel: BaseViewModel<HomeViewAction, HomeViewState> {
-    
-    @Published var routes = [HomeRoute]()
 
     @Injected(\.homeRouter) private var homeRouter: HomeRouter!
+    @Injected(\.mainViewRouter) private var mainViewRouter: MainViewRouter!
+    @Injected(\.settingsRouter) private var settingsRouter: SettingsRouter!
 
     // MARK: - Initialization
     
     init() {
         super.init(state: HomeViewState())
-        
-        setupBinding()
-    }
-    
-    private func setupBinding() {
-        homeRouter.routesPublisher
-            .receive(on: RunLoop.main)
-            .sink { [weak self] routes in
-                self?.routes = routes
-            }
-            .store(in: &cancellables)
     }
 
     // MARK: - Actions
@@ -35,7 +26,8 @@ class HomeViewModel: BaseViewModel<HomeViewAction, HomeViewState> {
         case .pressedTransactionDetails:
             homeRouter.presentTransactionDetailsFromHome()
         case .pressedSettings:
-            break
+            mainViewRouter.set(tab: .settings)
+            settingsRouter.presentEmailSettings()
         }
     }
 }

--- a/Modules/HomeInterface/Sources/HomeInterface/Router/HomeRouter.swift
+++ b/Modules/HomeInterface/Sources/HomeInterface/Router/HomeRouter.swift
@@ -4,9 +4,6 @@ import SwiftUI
 import Core
 
 public protocol HomeRouter: TabBarRouter {
-    var routes: [HomeRoute] { get }
-    var routesPublisher: Published<[HomeRoute]>.Publisher { get }
-
     func presentAccountList()
     func presentAccountDetails()
     func presentTransactionDetails()

--- a/Modules/Main/Sources/Main/Router/MainViewRouter.swift
+++ b/Modules/Main/Sources/Main/Router/MainViewRouter.swift
@@ -6,13 +6,34 @@ import MainInterface
 import HomeInterface
 import SettingsInterface
 
+public class MainViewNavigationState: ObservableObject {
+    @Published public var selectedTab: MainViewTab
+
+    public init(selectedTab: MainViewTab = .home) {
+        self.selectedTab = selectedTab
+    }
+}
+
 @MainActor
 public class MainViewRouterImplementation: MainViewRouter {
-    
-    @Injected(\.homeRouter) private var homeRouter: HomeRouter!
-    @Injected(\.settingsRouter) private var settingsRouter: SettingsRouter!
-    
-    public init() { }
+
+//    @Injected(\.homeRouter) private var homeRouter: HomeRouter!
+//    @Injected(\.settingsRouter) private var settingsRouter: SettingsRouter!
+
+    private var navigationState: MainViewNavigationState
+
+    private var homeRouter: HomeRouter
+    private var settingsRouter: SettingsRouter
+
+    public init(
+        navigationState: MainViewNavigationState = MainViewNavigationState(),
+        homeRouter: HomeRouter,
+        settingsRouter: SettingsRouter
+    ) {
+        self.navigationState = navigationState
+        self.homeRouter = homeRouter
+        self.settingsRouter = settingsRouter
+    }
     
     public func viewFor(tab: MainViewTab) -> AnyView {
         switch tab {
@@ -22,4 +43,13 @@ public class MainViewRouterImplementation: MainViewRouter {
             return settingsRouter.entryView()
         }
     }
+
+    public func set(tab: MainViewTab)  {
+        navigationState.selectedTab = tab
+    }
+
+    public func mainView() -> AnyView {
+        return AnyView(MainView(navigationState: navigationState))
+    }
+
 }

--- a/Modules/Main/Sources/Main/Stories/MainView.swift
+++ b/Modules/Main/Sources/Main/Stories/MainView.swift
@@ -6,10 +6,10 @@ public struct MainView: View {
     
     @Injected(\.mainViewRouter) private var router: MainViewRouter!
 
-    public init() { }
-    
+    @ObservedObject var navigationState: MainViewNavigationState
+
     public var body: some View {
-        TabView {
+        TabView(selection: $navigationState.selectedTab) {
             ForEach(MainViewTab.allCases) { tab in
                 router.viewFor(tab: tab)
                     .tabItem {

--- a/Modules/MainInterface/Sources/MainInterface/Router/MainViewRouter.swift
+++ b/Modules/MainInterface/Sources/MainInterface/Router/MainViewRouter.swift
@@ -3,4 +3,8 @@ import SwiftUI
 @MainActor
 public protocol MainViewRouter {
     func viewFor(tab: MainViewTab) -> AnyView
+
+    func set(tab: MainViewTab)
+
+    func mainView() -> AnyView
 }

--- a/Modules/Settings/Sources/Settings/Router/SettingsRouter.swift
+++ b/Modules/Settings/Sources/Settings/Router/SettingsRouter.swift
@@ -3,12 +3,52 @@ import Factory
 import SettingsInterface
 import Core
 
+public enum AccountSettingsRoute: Hashable {
+    case list
+    case detail
+}
+
+extension AccountSettingsRoute: View {
+
+    public var body: some View {
+        switch self {
+        case .list:
+            List {
+                Text("List")
+            }
+        case .detail:
+            Text("Detail")
+        }
+    }
+}
+
+
+public class SettingsNavigationState: ObservableObject {
+    @Published var accountSheetPresented: Bool = false
+    @Published var accountSettingsRoutes = [AccountSettingsRoute]()
+    var routesToRestore = [AccountSettingsRoute]()
+
+    public init() {
+
+    }
+
+    func restore() {
+        accountSettingsRoutes.removeAll()
+        accountSettingsRoutes.append(contentsOf: routesToRestore)
+        routesToRestore.removeAll()
+    }
+}
+
 final public class SettingsRouterImplementation: SettingsRouter {
-    
-    public init() { }
+
+    var navigationState: SettingsNavigationState
+
+    public init() {
+        navigationState = SettingsNavigationState()
+    }
     
     public func entryView() -> AnyView {
-        SettingsView().toAnyView()
+        SettingsView(navigationState: navigationState).toAnyView()
     }
     
     public func presentAccountSettings() {
@@ -17,7 +57,7 @@ final public class SettingsRouterImplementation: SettingsRouter {
     }
     
     public func presentEmailSettings() {
-        // TODO: Implement
-        print("presentEmailSettings")
+        navigationState.accountSheetPresented = true
+        navigationState.routesToRestore.append(contentsOf: [.detail])
     }
 }

--- a/Modules/Settings/Sources/Settings/Stories/Settings/SettingsView.swift
+++ b/Modules/Settings/Sources/Settings/Stories/Settings/SettingsView.swift
@@ -5,7 +5,9 @@ import Core
 struct SettingsView: View {
     
     @ObservedObject private var viewModel: SettingsViewModel = Container.shared.settingsViewModel()
-    
+
+    @ObservedObject var navigationState: SettingsNavigationState
+
     var body: some View {
         VStack(spacing: 24) {
             AsyncButton(action: {
@@ -27,5 +29,22 @@ struct SettingsView: View {
             })
         }
         .navigationTitle("Settings")
+        .sheet(isPresented: $navigationState.accountSheetPresented) {
+            NavigationStack(path: $navigationState.accountSettingsRoutes) {
+                List {
+                    AsyncButton(action: {
+                        navigationState.accountSettingsRoutes.append(.detail)
+                    }, label: {
+                        Text("Details view")
+                    })
+
+                }
+                .navigationTitle("Home")
+                .navigationDestination(for: AccountSettingsRoute.self) { $0 }
+            }
+            .task {
+                navigationState.restore()
+            }
+        }
     }
 }

--- a/Test/DI/Main+Injection.swift
+++ b/Test/DI/Main+Injection.swift
@@ -6,6 +6,9 @@ import MainInterface
 extension Container {
     @MainActor
     public func autoRegisterMainDependencies() {
-        mainViewRouter.register { MainViewRouterImplementation() }
+        mainViewRouter.register { MainViewRouterImplementation(
+            homeRouter: self.homeRouter.callAsFunction()!,
+            settingsRouter: self.settingsRouter.callAsFunction()!
+        ) }
     }
 }

--- a/Test/TestApp.swift
+++ b/Test/TestApp.swift
@@ -1,12 +1,15 @@
 import SwiftUI
-import Main
+import Factory
+import MainInterface
 
 @main
 struct TestApp: App {
+
+    @Injected(\.mainViewRouter) private var mainViewRouter: MainViewRouter!
+
     var body: some Scene {
         WindowGroup {
-            MainView()
-//            ContentView()
+            mainViewRouter.mainView()
         }
     }
 }


### PR DESCRIPTION
**What's new**

- Added `NavigationState` classes for routers. Each router can have a navigation state that holds an array with routes and any sheet, alert etc. presentation state.  `SettingsNavigationState` is the best example here. It allows for deeplinking. In this PR, you can click on "Go to settings" in home screen (`HomeModule`) and you will be taken to a modal sheet with detail view in settings module. 
- Having separate navigation state will also possible allow us to restore the navigation state if the app was killed by the system and reopened. It should be easily doable as we could serialise `NavigationState` of each router, save it to some storage and recreate it.